### PR TITLE
Best practices update

### DIFF
--- a/TerraSpin/container/Dockerfile
+++ b/TerraSpin/container/Dockerfile
@@ -1,10 +1,9 @@
 FROM opsmx11/java:ubuntu16_java8
-MAINTAINER OpsMx
+
 COPY TerraSpin/container/terraform  /usr/local/bin/terraform
 #COPY /git  /usr/bin/git
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git
+    apt-get install -y --no-install-recommends git
 RUN groupadd -g 999 terraspin && \
     useradd -r -u 999 -g terraspin terraspin
 RUN mkdir -p /home/terraspin


### PR DESCRIPTION
This PR contains the following: 

1. Removing `apt-get upgrade`. It is best to avoid RUN apt-get upgrade, as many of the “essential” packages from the parent images cannot upgrade inside an unprivileged container.
2. Adding `--no-install-recommends`. This avoids the installation of recommended packages thus reducing image size
3. `MAINTAINER` has been [deprecated](https://riptutorial.com/docker/example/11010/maintainer-instruction)

This addresses issue #3 

Signed-off-by: markyjackson-taulia <marky.r.jackson@gmail.com>